### PR TITLE
Drop redundant source numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Summary:        A simple Python 3 library for Notion Home Monitoring
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
 License:        MIT
 URL:            https://github.com/bachya/aionotion
-Source0:        %{pypi_source aionotion}
+Source:         %{pypi_source aionotion}
 
 BuildArch:      noarch
 BuildRequires:  python3-devel

--- a/pyp2spec/template.spec
+++ b/pyp2spec/template.spec
@@ -7,7 +7,7 @@ Summary:        {{summary}}
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
 License:        {{license}}
 URL:            {{url}}
-Source0:        {{source}}
+Source:         {{source}}
 {% if not archful %}
 BuildArch:      noarch
 {%- endif %}

--- a/tests/expected_specfiles/python-click.spec
+++ b/tests/expected_specfiles/python-click.spec
@@ -7,7 +7,7 @@ Summary:        Composable command line interface toolkit
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
 License:        BSD
 URL:            https://palletsprojects.com/p/click/
-Source0:        %{pypi_source click}
+Source:         %{pypi_source click}
 
 BuildArch:      noarch
 BuildRequires:  python3-devel

--- a/tests/expected_specfiles/python-markdown-it-py.spec
+++ b/tests/expected_specfiles/python-markdown-it-py.spec
@@ -7,7 +7,7 @@ Summary:        Python port of markdown-it
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
 License:        MIT
 URL:            https://github.com/executablebooks/markdown-it-py
-Source0:        %{url}/archive/v%{version}/markdown-it-py-%{version}.tar.gz
+Source:         %{url}/archive/v%{version}/markdown-it-py-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel


### PR DESCRIPTION
Relevant change in Fedora's packaging guidelines:
https://pagure.io/packaging-committee/pull-request/1157

Done by:

    sed -i 's/Source0:/Source: /' $(rg -l Source0)