### PR TITLE
Change default changelog message

### DIFF
--- a/pyp2spec/pyp2conf.py
+++ b/pyp2spec/pyp2conf.py
@@ -233,7 +233,7 @@ def changelog_head(email, name, changelog_date):
 def changelog_msg():
     """Return a default changelog message."""
 
-    return "Package generated with pyp2spec"
+    return "Initial package"
 
 
 def get_description(package):

--- a/tests/expected_specfiles/python-click.spec
+++ b/tests/expected_specfiles/python-click.spec
@@ -54,4 +54,4 @@ Summary:        %{summary}
 
 %changelog
 * Wed Nov 03 2021 Packager <packager@maint.com> - 7.1.2-1
-- Package generated with pyp2spec
+- Initial package

--- a/tests/test_configs/default_python-aionotion.conf
+++ b/tests/test_configs/default_python-aionotion.conf
@@ -1,4 +1,4 @@
-changelog_msg = "Package generated with pyp2spec"
+changelog_msg = "Initial package"
 changelog_head = "Wed Nov 03 2021 Packager <packager@maint.com>"
 description = "This is package 'aionotion' generated automatically by pyp2spec."
 summary = "A simple Python 3 library for Notion Home Monitoring"

--- a/tests/test_configs/default_python-click.conf
+++ b/tests/test_configs/default_python-click.conf
@@ -1,4 +1,4 @@
-changelog_msg = "Package generated with pyp2spec"
+changelog_msg = "Initial package"
 changelog_head = "Wed Nov 03 2021 Packager <packager@maint.com>"
 description = "This is package 'click' generated automatically by pyp2spec."
 summary = "Composable command line interface toolkit"


### PR DESCRIPTION
At least when packaging for Fedora, the fact that the specfile is
generated by pyp2spec is irrelevant as far as the changelog is
concerned. Generally, the initial changelog
entry is "Initial package" or something similar.

Signed-off-by: Maxwell G <gotmax@e.email>