### PR TITLE
replace sys.exit's with saner error handling

### DIFF
--- a/pyp2spec/license_processor.py
+++ b/pyp2spec/license_processor.py
@@ -4,9 +4,19 @@ import json
 import requests
 from license_expression import get_spdx_licensing, ExpressionError
 
+from pyp2spec.utils import Pyp2specError
+
 
 TROVE2FEDORA_MAP = {}
 FEDORA_LICENSES = {}
+
+
+class NoSuchClassifierError(Pyp2specError):
+    """Raised when the detected license classifier doesn't exist in pyp2spec's data"""
+
+
+class InvalidSPDXExpressionError(Pyp2specError):
+    """Raised when the assumed SPDX expression is not valid"""
 
 
 def _load_package_resource(filename):
@@ -45,7 +55,7 @@ def classifiers_to_spdx_identifiers(classifiers):
             err_string = f"{classifier}: Such classifier doesn't exist. " \
             "If you believe that's pyp2spec's error, open an issue at the project's GitHub repo: " \
             "https://github.com/befeleme/pyp2spec"
-            raise KeyError(err_string) from err
+            raise NoSuchClassifierError(err_string) from err
 
         # Classifiers that don't map unambiguously to a single Fedora SPDX expression are nulls
         # in the json
@@ -85,7 +95,7 @@ def license_keyword_to_spdx_identifiers(license_keyword):
         # The objects are stored in sets, sort and return as a list
         return sorted(parsed_license.objects)
     except ExpressionError as err:
-        raise ValueError(f"Invalid SPDX expression: {license_keyword}") from err
+        raise InvalidSPDXExpressionError(f"Invalid SPDX expression: {license_keyword}") from err
 
 
 def _load_fedora_licenses(source_path=None, session=None):

--- a/pyp2spec/pyp2spec.py
+++ b/pyp2spec/pyp2spec.py
@@ -1,7 +1,10 @@
+import sys
+
 import click
 
 from pyp2spec.pyp2conf import create_config, pypconf_args
 from pyp2spec.conf2spec import create_spec_file
+from pyp2spec.utils import Pyp2specError
 
 
 @click.command()
@@ -12,9 +15,13 @@ from pyp2spec.conf2spec import create_spec_file
 )
 def main(**options):
     click.secho("Generating configuration file", fg="cyan")
-    config_file = create_config(options)
-    click.secho("Generating spec file", fg="cyan")
-    create_spec_file(config_file, options["spec_output"])
+    try:
+        config_file = create_config(options)
+        click.secho("Generating spec file", fg="cyan")
+        create_spec_file(config_file, options["spec_output"])
+    except (Pyp2specError, NotImplementedError) as exc:
+        click.secho(f"Fatal exception occurred: {exc}", fg="red")
+        sys.exit(1)
     click.secho("Done", fg="green")
 
 

--- a/pyp2spec/utils.py
+++ b/pyp2spec/utils.py
@@ -1,0 +1,2 @@
+class Pyp2specError(Exception):
+    """Metaexception to derive the custom errors from"""

--- a/tests/test_license_processor.py
+++ b/tests/test_license_processor.py
@@ -2,6 +2,7 @@ import pytest
 
 from pyp2spec.license_processor import classifiers_to_spdx_identifiers, license_keyword_to_spdx_identifiers
 from pyp2spec.license_processor import _is_compliant_with_fedora, good_for_fedora
+from pyp2spec.license_processor import InvalidSPDXExpressionError, NoSuchClassifierError
 
 
 @pytest.mark.parametrize(
@@ -20,12 +21,13 @@ def test_classifiers_to_spdx_identifiers(classifiers, spdx_identifiers):
 
 @pytest.mark.parametrize(
     ("classifiers"),  (
+        ["License :: OSI Approved :: XXXXXX"],
         ["Non-existing-classifier"],
         [""]
     ),
 )
 def test_conversion_to_spdx_fails_for_invalid_inputs(classifiers):
-    with pytest.raises(KeyError):
+    with pytest.raises(NoSuchClassifierError):
         classifiers_to_spdx_identifiers(classifiers)
 
 
@@ -60,7 +62,7 @@ def test_perl_license_raises_exception():
     ),
 )
 def test_invalid_expressions_raise_errors(expression):
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidSPDXExpressionError):
         license_keyword_to_spdx_identifiers(expression)
 
 


### PR DESCRIPTION
The first attempt to handle errors in a saner manner:
- functions either return something meaningful or raise a sensible exception. `sys.exit`s are only raised in the main script's calls. 
- this comes with a significant reduce of various `click.secho`s, preferably to none outside of the direct script's calls