### PR TITLE
Support for pyproject declarative buildsystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches:
+      - main
   pull_request:
 jobs:
   unit_test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 - Support for compat packages of various granularity (eg. '7', '7.2').
 Invoke with `--compat <compat-version-string>`
+- Support for pyproject declarative buildsystem, [rpm documentation](https://rpm-software-management.github.io/rpm/manual/buildsystem.html), [pyproject-rpm-macros documentation](https://src.fedoraproject.org/rpms/pyproject-rpm-macros)
+  - section 'Provisional: Declarative Buildsystem (RPM 4.20+)'.
 
 
 # [0.11.1] - 2024-11-21

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ The defaults:
 The generated spec files don't fulfill all the necessities of the official
 Fedora packages and hence cannot be submitted for review.
 
+### pyproject declarative buildsystem (experimental)
+
+pyp2spec can create spec files with a new feature of rpm >= 4.20 and pyproject
+RPM macros, called declarative buildsystem.
+Invoke it with the `--declarative-buildsystem` command-line option.
+It is inactive by default. It doesn't work combined with automode.
+
+For details, see [rpm documentation](https://rpm-software-management.github.io/rpm/manual/buildsystem.html)
+and [pyproject-rpm-macros documentation](https://src.fedoraproject.org/rpms/pyproject-rpm-macros)
+- look for the section 'Provisional: Declarative Buildsystem (RPM 4.20+)').
+
+
 ## How to run
 
 To run whatever this project offers at this point,
@@ -205,6 +217,54 @@ Summary:        %{summary}
 %autochangelog
 ```
 
+### Declarative buildsystem spec file (experimental)
+
+```
+Name:           python-aionotion
+Version:        2024.3.1
+Release:        %autorelease
+# Fill in the actual package summary to submit package to Fedora
+Summary:        A simple Python 3 library for Notion Home Monitoring
+
+# Check if the automatically generated License and its spelling is correct for Fedora
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
+License:        MIT
+URL:            ...
+Source:         %{pypi_source aionotion}
+
+BuildSystem:    pyproject
+# Replace ... with top-level Python module names as arguments, you can use globs
+BuildOption(install):  ...
+# Keep only those extras which you actually want to package or use during tests
+# If you don't want to package any of them, erase the whole line
+BuildOption(generate_buildrequires): -x build,lint,test
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+
+
+# Fill in the actual package description to submit package to Fedora
+%global _description %{expand:
+This is package 'aionotion' generated automatically by pyp2spec.}
+
+%description %_description
+
+%package -n     python3-aionotion
+Summary:        %{summary}
+
+%description -n python3-aionotion %_description
+
+# For official Fedora packages, review which extras should be actually packaged
+# See: https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#Extras
+%pyproject_extras_subpkg -n python3-aionotion build,lint,test
+
+
+%files -n python3-aionotion -f %{pyproject_files}
+
+
+%changelog
+%autochangelog
+```
 
 ## License
 

--- a/pyp2spec/conf2spec.py
+++ b/pyp2spec/conf2spec.py
@@ -204,11 +204,13 @@ def fill_in_template(config: ConfigFile, declarative_buildsystem: bool) -> str:
     return result
 
 
-def save_spec_file(config: ConfigFile, output: str | None, declarative_buildsystem: bool) -> str:
+def save_spec_file(config: ConfigFile, options: dict[str, Any]) -> str:
     """Save the spec file in the current directory if custom output is not set.
     Return the saved file name."""
 
+    declarative_buildsystem = options.get("declarative_buildsystem", False)
     result = fill_in_template(config, declarative_buildsystem)
+    output = options.get("spec_output")
     if output is None:
         output = create_compat_name(config.get_string("python_name"), config.get_string("compat"))
         output += ".spec"
@@ -218,10 +220,10 @@ def save_spec_file(config: ConfigFile, output: str | None, declarative_buildsyst
     return output
 
 
-def create_spec_file(config_file: str, spec_output: str | None=None, declarative_buildsystem: bool=False) -> str | None:
+def create_spec_file(config_file: str, options: dict[str, Any]) -> str | None:
     """Create and save the generate spec file."""
     config = ConfigFile(load_config_file(config_file))
-    return save_spec_file(config, spec_output, declarative_buildsystem)
+    return save_spec_file(config, options)
 
 
 @click.command()
@@ -235,9 +237,9 @@ def create_spec_file(config_file: str, spec_output: str | None=None, declarative
     "--declarative-buildsystem", is_flag=True, default=False,
     help="Create a spec file with pyproject declarative buildsystem (experimental)",
 )
-def main(config: str, spec_output: str, declarative_buildsystem: bool) -> None:
+def main(config: str, **options: dict[str, Any]) -> None:
     try:
-        create_spec_file(config, spec_output, declarative_buildsystem)
+        create_spec_file(config, options)
     except (Pyp2specError, NotImplementedError) as exc:
         warn(f"Fatal exception occurred: {exc}")
         sys.exit(1)

--- a/pyp2spec/pyp2spec.py
+++ b/pyp2spec/pyp2spec.py
@@ -23,7 +23,7 @@ def main(**options):  # noqa
         if options["automode"] and options["declarative_buildsystem"]:
             raise Pyp2specError("Declarative buildsystem doesn't work with automode")
         config_file = create_config(options)
-        create_spec_file(config_file, options["spec_output"], options["declarative_buildsystem"])
+        create_spec_file(config_file, options)
     except (Pyp2specError, NotImplementedError) as exc:
         warn(f"Fatal exception occurred: {exc}")
         sys.exit(1)

--- a/pyp2spec/pyp2spec.py
+++ b/pyp2spec/pyp2spec.py
@@ -14,10 +14,16 @@ from pyp2spec.utils import warn
     "--spec-output", "-o",
     help="Provide custom output where spec file will be saved",
 )
+@click.option(
+    "--declarative-buildsystem", is_flag=True, default=False,
+    help="Create a spec file with pyproject declarative buildsystem (experimental)",
+)
 def main(**options):  # noqa
     try:
+        if options["automode"] and options["declarative_buildsystem"]:
+            raise Pyp2specError("Declarative buildsystem doesn't work with automode")
         config_file = create_config(options)
-        create_spec_file(config_file, options["spec_output"])
+        create_spec_file(config_file, options["spec_output"], options["declarative_buildsystem"])
     except (Pyp2specError, NotImplementedError) as exc:
         warn(f"Fatal exception occurred: {exc}")
         sys.exit(1)

--- a/pyp2spec/template.spec
+++ b/pyp2spec/template.spec
@@ -12,6 +12,17 @@ Summary:        {{summary}}
 License:        {{license}}
 URL:            {{url}}
 Source:         {{source}}
+{% if declarative_buildsystem %}
+BuildSystem:    pyproject
+# Replace ... with top-level Python module names as arguments, you can use globs
+BuildOption(install): {% if mandate_license %} -l{% endif %} ...
+{% if extras -%}
+# Keep only those extras which you actually want to package or use during tests
+# If you don't want to package any of them, erase the whole line
+BuildOption(generate_buildrequires): -x {{extras}}
+{% endif -%}
+{% endif -%}
+
 {% if not archful %}
 BuildArch:      noarch
 {%- endif %}
@@ -42,6 +53,7 @@ Provides:       deprecated()
 %pyproject_extras_subpkg -n python{{python3_pkgversion}}-{{name}} {{extras}}
 {% endif %}
 
+{% if not declarative_buildsystem -%}
 %prep
 %autosetup -p1 -n {{archive_name}}-{{pypi_version}}
 
@@ -77,6 +89,7 @@ Provides:       deprecated()
 {%- endif %}
 
 
+{% endif -%}
 %files -n python{{python3_pkgversion}}-{{compat_name}} -f %{pyproject_files}
 
 

--- a/tests/expected_specfiles/python-pello.spec
+++ b/tests/expected_specfiles/python-pello.spec
@@ -1,0 +1,44 @@
+Name:           python-pello
+Version:        1.0.4
+Release:        %autorelease
+# Fill in the actual package summary to submit package to Fedora
+Summary:        An example Python Hello World package
+
+# Check if the automatically generated License and its spelling is correct for Fedora
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/
+License:        MIT-0
+URL:            https://github.com/fedora-python/Pello
+Source:         %{pypi_source Pello}
+
+BuildSystem:    pyproject
+# Replace ... with top-level Python module names as arguments, you can use globs
+BuildOption(install):  -l ...
+# Keep only those extras which you actually want to package or use during tests
+# If you don't want to package any of them, erase the whole line
+BuildOption(generate_buildrequires): -x color
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+
+
+# Fill in the actual package description to submit package to Fedora
+%global _description %{expand:
+This is package 'pello' generated automatically by pyp2spec.}
+
+%description %_description
+
+%package -n     python3-pello
+Summary:        %{summary}
+
+%description -n python3-pello %_description
+
+# For official Fedora packages, review which extras should be actually packaged
+# See: https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#Extras
+%pyproject_extras_subpkg -n python3-pello color
+
+
+%files -n python3-pello -f %{pyproject_files}
+
+
+%changelog
+%autochangelog

--- a/tests/test_conf2spec.py
+++ b/tests/test_conf2spec.py
@@ -56,7 +56,7 @@ def test_archful_flag_is_loaded(config_dir, conf, expected):
 )
 def test_default_generated_specfile(file_regression, config_dir, conf, db):
     # Run the conf2spec converter
-    rendered_file = conf2spec.create_spec_file(config_dir + conf, declarative_buildsystem=db)
+    rendered_file = conf2spec.create_spec_file(config_dir + conf, {"declarative_buildsystem": db})
 
     # Compare the results
     with open(rendered_file, "r", encoding="utf-8") as rendered_f:

--- a/tests/test_conf2spec.py
+++ b/tests/test_conf2spec.py
@@ -42,20 +42,21 @@ def test_archful_flag_is_loaded(config_dir, conf, expected):
 
 
 @pytest.mark.parametrize(
-    "conf", [
-        "default_python-click.conf",  # default, noarch, no quirks
-        "customized_markdown-it-py.conf",  # automode on
-        "customized_python-sphinx.conf",  # contains extras
-        "default_python-numpy.conf",  # archful
-        "default_python3.9-pello.conf",  # custom Python version
-        "default_python-pytest7.2.conf",  # compat version
-        "default_python-pytest7.conf",  # compat version - lower granularity
-        "default_python-urllib3_2.conf",  # compat version - pkgname with a digit
+    ("conf", "db"), [
+        ("default_python-click.conf", False),  # default, noarch, no quirks
+        ("customized_markdown-it-py.conf", False),  # automode on
+        ("customized_python-sphinx.conf", False),  # contains extras
+        ("default_python-numpy.conf", False),  # archful
+        ("default_python3.9-pello.conf", False),  # custom Python version
+        ("default_python-pytest7.2.conf", False),  # compat version
+        ("default_python-pytest7.conf", False),  # compat version - lower granularity
+        ("default_python-urllib3_2.conf", False), # compat version - pkgname with a digit
+        ("default_python-pello.conf", True),  # declarative build system
     ]
 )
-def test_default_generated_specfile(file_regression, config_dir, conf):
+def test_default_generated_specfile(file_regression, config_dir, conf, db):
     # Run the conf2spec converter
-    rendered_file = conf2spec.create_spec_file(config_dir + conf)
+    rendered_file = conf2spec.create_spec_file(config_dir + conf, declarative_buildsystem=db)
 
     # Compare the results
     with open(rendered_file, "r", encoding="utf-8") as rendered_f:

--- a/tests/test_configs/default_python-pello.conf
+++ b/tests/test_configs/default_python-pello.conf
@@ -1,0 +1,13 @@
+archful = false
+archive_name = "Pello-1.0.4.tar.gz"
+extras = [
+    "color",
+]
+license = "MIT-0"
+license_files_present = true
+pypi_name = "pello"
+pypi_version = "1.0.4"
+python_name = "python-pello"
+source = "PyPI"
+summary = "An example Python Hello World package"
+url = "https://github.com/fedora-python/Pello"


### PR DESCRIPTION
Based on top of #54 

This brings the support for pyproject declarative buildsystem (invoked from cli `--declarative-buildsystem`). 
Closes #51 