### PR TITLE
Try project_url and package_url from the metadata in addition to home_page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.12.1] - 2025-04-07
+### Fixed
+- If no `project_urls` are present in the package data, try `project_url` and
+fall back to `package_url`
+
 # [0.12.0] - 2025-03-03
 ### Added
 - Support for compat packages of various granularity (eg. '7', '7.2').

--- a/pyp2spec/pyp2conf.py
+++ b/pyp2spec/pyp2conf.py
@@ -48,6 +48,10 @@ def prepare_package_info(data: RawMetadata | dict) -> PackageInfo:
     if not (project_urls := data.get("project_urls", {})):
         if (homepage := data.get("home_page", "")):
             project_urls["home_page"] = homepage
+        if (not homepage and (homepage := data.get("project_url", ""))):
+            project_urls["home_page"] = homepage
+        if (not homepage and (homepage := data.get("package_url", ""))):
+            project_urls["home_page"] = homepage
     return PackageInfo(
         pypi_name=normalize_name(data.get("name", "")),
         pypi_version=data.get("version", ""),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyp2spec"
-version = "0.12.0"
+version = "0.12.1"
 description = "Generate a valid Fedora specfile from Python package from PyPI"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/tests/test_pyp2conf.py
+++ b/tests/test_pyp2conf.py
@@ -277,6 +277,86 @@ def test_prepare_package_info_missing_keys():
     assert result.url == "..."
 
 
+def test_prepare_package_info_only_package_url():
+    data = {
+        "name": "foo",
+        "package_url": "https://example.com",
+    }
+    result = prepare_package_info(data)
+    assert result.pypi_name == "foo"
+    assert result.summary == "..."
+    assert result.license_files_present is False
+    assert result.license is None
+    assert result.extras == []
+    assert result.pypi_version == ""
+    assert result.url == "https://example.com"
+
+
+def test_prepare_package_info_only_project_url():
+    data = {
+        "name": "foo",
+        "project_url": "https://example.com",
+    }
+    result = prepare_package_info(data)
+    assert result.pypi_name == "foo"
+    assert result.summary == "..."
+    assert result.license_files_present is False
+    assert result.license is None
+    assert result.extras == []
+    assert result.pypi_version == ""
+    assert result.url == "https://example.com"
+
+
+def test_prepare_package_info_project_urls_precedance():
+    data = {
+        "name": "foo",
+        "project_url": "https://example1.com",
+        "package_url": "https://example2.com",
+        "project_urls": {"Homepage": "https://example3.com"},
+    }
+    result = prepare_package_info(data)
+    assert result.pypi_name == "foo"
+    assert result.summary == "..."
+    assert result.license_files_present is False
+    assert result.license is None
+    assert result.extras == []
+    assert result.pypi_version == ""
+    assert result.url == "https://example3.com"
+
+
+def test_prepare_package_info_home_page_precedance():
+    data = {
+        "name": "foo",
+        "project_url": "https://example1.com",
+        "package_url": "https://example2.com",
+        "home_page": "https://example3.com",
+    }
+    result = prepare_package_info(data)
+    assert result.pypi_name == "foo"
+    assert result.summary == "..."
+    assert result.license_files_present is False
+    assert result.license is None
+    assert result.extras == []
+    assert result.pypi_version == ""
+    assert result.url == "https://example3.com"
+
+
+def test_prepare_package_info_project_url_precedance():
+    data = {
+        "name": "foo",
+        "project_url": "https://example1.com",
+        "package_url": "https://example2.com",
+    }
+    result = prepare_package_info(data)
+    assert result.pypi_name == "foo"
+    assert result.summary == "..."
+    assert result.license_files_present is False
+    assert result.license is None
+    assert result.extras == []
+    assert result.pypi_version == ""
+    assert result.url == "https://example1.com"
+
+
 def test_gather_package_info_pypi_source():
     pypi = {"info": {
         "name": "example",


### PR DESCRIPTION
The pandoc package metdata only has url values in project_url and package_url, causing the process to crash with:

``` python
File "/usr/lib/python3.13/site-packages/pyp2spec/utils.py", line 186, in resolve_url
  normalized_urls = {_normalize_url_label(k): v for k, v in urls.items()}
                                                              ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'items'
```
because urls is None, as the pandoc metadata includes neither home_page or project_urls.