### PR TITLE
Ensure project_urls is not None when it's "project_urls": null in the json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.spec
 *.conf
 .tox/
+pyp2spec.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# [0.12.2] - 2025-04-15
+### Fixed
+- Also avoid crashing when you get a specifically None `project_urls` from the json
+
 # [0.12.1] - 2025-04-07
 ### Fixed
 - If no `project_urls` are present in the package data, try `project_url` and

--- a/pyp2spec/pyp2conf.py
+++ b/pyp2spec/pyp2conf.py
@@ -45,7 +45,7 @@ def is_package_name(package: str) -> bool:
 
 
 def prepare_package_info(data: RawMetadata | dict) -> PackageInfo:
-    if not (project_urls := data.get("project_urls", {})):
+    if not (project_urls := data.get("project_urls") or {}):
         if (homepage := data.get("home_page", "")):
             project_urls["home_page"] = homepage
         if (not homepage and (homepage := data.get("project_url", ""))):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyp2spec"
-version = "0.12.1"
+version = "0.12.2"
 description = "Generate a valid Fedora specfile from Python package from PyPI"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/tests/test_pyp2conf.py
+++ b/tests/test_pyp2conf.py
@@ -357,6 +357,24 @@ def test_prepare_package_info_project_url_precedance():
     assert result.url == "https://example1.com"
 
 
+def test_prepare_package_info_project_url_precedance_with_nulls():
+    data = {
+        "name": "foo",
+        "project_urls": None,
+        "project_url": None,
+        "home_page": None,
+        "package_url": "https://example1.com",
+    }
+    result = prepare_package_info(data)
+    assert result.pypi_name == "foo"
+    assert result.summary == "..."
+    assert result.license_files_present is False
+    assert result.license is None
+    assert result.extras == []
+    assert result.pypi_version == ""
+    assert result.url == "https://example1.com"
+
+
 def test_gather_package_info_pypi_source():
     pypi = {"info": {
         "name": "example",


### PR DESCRIPTION
Another buglet from the pandoc package, where all the unspecified fields as specifically returned as null, ie. `"package_urls": null`, which avoids the default value.